### PR TITLE
platform: replace glFramebufferTextureEXT with glFramebufferTexture

### DIFF
--- a/src/platform/platform.cpp
+++ b/src/platform/platform.cpp
@@ -90,7 +90,7 @@ bool GLRenderCtx::begin() {
         );
         glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depth);
 
-        glFramebufferTextureEXT(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, m_texture, 0);
+        glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, m_texture, 0);
     }
 
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {


### PR DESCRIPTION
Fixes a crash when running via wine.