### PR TITLE
Fix 2 crashes

### DIFF
--- a/src/pages/Attributes.cpp
+++ b/src/pages/Attributes.cpp
@@ -48,11 +48,16 @@ void DevTools::drawNodeAttributes(CCNode* node) {
 
     if (auto menuItemNode = typeinfo_cast<CCMenuItem*>(node)) {
         const auto selector = menuItemNode->m_pfnSelector;
-        const auto addr = formatAddressIntoOffset(addresser::getNonVirtual(selector));
-        ImGui::Text("CCMenuItem selector: %s", addr.c_str());
-        ImGui::SameLine();
-        if (ImGui::Button(U8STR(FEATHER_COPY " Copy##copymenuitem"))) {
-            clipboard::write(addr);
+        if (!selector) {
+            std::string addr = "N/A";
+            ImGui::Text("CCMenuItem selector: %s", addr.c_str());
+        } else {
+            const auto addr = formatAddressIntoOffset(addresser::getNonVirtual(selector));
+            ImGui::Text("CCMenuItem selector: %s", addr.c_str());
+            ImGui::SameLine();
+            if (ImGui::Button(U8STR(FEATHER_COPY " Copy##copymenuitem"))) {
+                clipboard::write(addr);
+            }
         }
     }
 

--- a/src/pages/GeometryDash.cpp
+++ b/src/pages/GeometryDash.cpp
@@ -199,6 +199,15 @@ void DevTools::drawHighlight(CCNode* node, HighlightMode mode) {
         max.y / wsize.y * rect.GetHeight() + rect.Min.y
     );
 
+    if (
+        isnan(tmax.x) ||
+        isnan(tmax.y) ||
+        isnan(tmin.x) ||
+        isnan(tmin.y)
+    ) {
+        return;
+    }
+
     auto anchor = ImVec2(
         node->getAnchorPoint().x * (tmax.x - tmin.x) + tmin.x,
         node->getAnchorPoint().y * (tmax.y - tmin.y) + tmin.y


### PR DESCRIPTION
This PR fixes 2 crashes:

- Trying to render attributes for a CCMenuItem with a nullptr menu_selector
- Trying to render highlights for a node that has invalid bounding box / positioning