### PR TITLE
Fix crash when controller stick is held on startup

### DIFF
--- a/src/DevTools.cpp
+++ b/src/DevTools.cpp
@@ -24,6 +24,10 @@ bool DevTools::pausedGame() const {
     return m_pauseGame;
 }
 
+bool DevTools::isSetup() const {
+    return m_setup;
+}
+
 CCNode* DevTools::getSelectedNode() const {
     return m_selectedNode;
 }

--- a/src/DevTools.hpp
+++ b/src/DevTools.hpp
@@ -71,6 +71,7 @@ public:
 
     bool shouldPopGame() const;
     bool pausedGame() const;
+    bool isSetup() const;
 
     CCNode* getSelectedNode() const;
     void selectNode(CCNode* node);

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -141,6 +141,8 @@ static float SCROLL_SENSITIVITY = 10;
 
 class $modify(CCMouseDispatcher) {
     bool dispatchScrollMSG(float y, float x) {
+        if(!DevTools::get()->isSetup()) return true;
+
         auto& io = ImGui::GetIO();
         io.AddMouseWheelEvent(x / SCROLL_SENSITIVITY, -y / SCROLL_SENSITIVITY);
 


### PR DESCRIPTION
This PR fixes an issue where the game crashes on startup, if the right controller thumbstick is held during that time.

This crash occurs because the CCMouseDispatcher hook attempts to send the mouse wheel event to ImGui before it is initialized. This PR simply adds a check that prevents this from happening before DevTools is initialized.

One thing I am not sure about is whether the code in this PR matches the code style used in the mod. If it doesn't then feel free to use this just as a starting point for the idea of how to implement a fix for the issue, the code in the PR is verified to be fully working.

~~i wasted half an hour just staring at an error message because of this issue~~