### PR TITLE
Fix DevTools for 2.204

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -1,7 +1,7 @@
 {
 	"geode": "v2.0.0",
 	"version": "v1.3.0",
-	"gd": "2.204",
+	"gd": "*",
 	"id": "geode.devtools",
 	"name": "DevTools",
 	"developer": "Geode Team",

--- a/mod.json
+++ b/mod.json
@@ -1,6 +1,7 @@
 {
 	"geode": "v2.0.0",
 	"version": "v1.3.0",
+	"gd": "2.204",
 	"id": "geode.devtools",
 	"name": "DevTools",
 	"developer": "Geode Team",

--- a/src/pages/Advanced.cpp
+++ b/src/pages/Advanced.cpp
@@ -176,7 +176,7 @@ void DevTools::drawModGraphNode(Mod* node) {
 
     node->setMetadata(this->inputMetadata(node, node->getMetadata()));
 
-    ImGui::Text("supportsDisabling: %s", node->supportsDisabling() ? "true" : "false");
+    ImGui::Text("isInternal: %s", node->isInternal() ? "true" : "false");
     ImGui::Text("early: %s", node->needsEarlyLoad() ? "true" : "false");
     ImGui::Text("hasUnresolvedDependencies: %s", node->hasUnresolvedDependencies() ? "true" : "false");
     ImGui::Text("hasUnresolvedIncompatibilities: %s", node->hasUnresolvedIncompatibilities() ? "true" : "false");


### PR DESCRIPTION
This allows DevTools to be used in 2.204, since Geode requires "gd" in mod.json, and `supportsDisabling` is no longer a method.