### PR TITLE
fix fullscreen toggling

### DIFF
--- a/src/DevTools.hpp
+++ b/src/DevTools.hpp
@@ -8,7 +8,6 @@
 #include <Geode/utils/addresser.hpp>
 #include <Geode/loader/Loader.hpp>
 #include <Geode/loader/ModMetadata.hpp>
-#include <unordered_map>
 
 using namespace geode::prelude;
 
@@ -44,6 +43,7 @@ protected:
     ImFont* m_smallFont    = nullptr;
     ImFont* m_monoFont     = nullptr;
     ImFont* m_boxFont      = nullptr;
+    CCTexture2D* m_fontTexture = nullptr;
     Ref<CCNode> m_selectedNode;
     std::vector<std::pair<CCNode*, HighlightMode>> m_toHighlight;
 

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -12,8 +12,6 @@ using namespace cocos2d;
 // based off https://github.com/matcool/gd-imgui-cocos
 
 void DevTools::setupPlatform() {
-    ImGui::CreateContext();
-
     auto& io = ImGui::GetIO();
 
     io.BackendPlatformUserData = this;
@@ -29,13 +27,11 @@ void DevTools::setupPlatform() {
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
 
-    auto* tex2d = new CCTexture2D;
-    tex2d->initWithData(pixels, kCCTexture2DPixelFormat_RGBA8888, width, height, CCSize(width, height));
+    m_fontTexture = new CCTexture2D;
+    m_fontTexture->initWithData(pixels, kCCTexture2DPixelFormat_RGBA8888, width, height, CCSize(width, height));
+    m_fontTexture->retain();
 
-    // TODO: not leak this :-)
-    tex2d->retain();
-
-    io.Fonts->SetTexID(reinterpret_cast<ImTextureID>(static_cast<intptr_t>(tex2d->getName())));
+    io.Fonts->SetTexID(reinterpret_cast<ImTextureID>(static_cast<intptr_t>(m_fontTexture->getName())));
 }
 
 void DevTools::newFrame() {


### PR DESCRIPTION
Fixes a few issues that happened when toggling fullscreen, such as:

- imgui taking ownership of static font data
- imgui context not being correctly destroyed (thanks prevter and mat)
- font texture being leaked on every setup
- imgui theme not being reapplied when destroying and recreating devtools