### PR TITLE
Add node properties API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ add_subdirectory($ENV{GEODE_SDK} ${CMAKE_CURRENT_BINARY_DIR}/geode)
 
 CPMAddPackage("gh:ocornut/imgui@1.91.0-docking")
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${imgui_SOURCE_DIR})
+target_include_directories(${PROJECT_NAME} PRIVATE ${imgui_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 target_sources(${PROJECT_NAME} PRIVATE
     ${imgui_SOURCE_DIR}/imgui.cpp

--- a/include/API.hpp
+++ b/include/API.hpp
@@ -1,0 +1,153 @@
+#pragma once
+#include <Geode/loader/Event.hpp>
+#include <Geode/loader/Mod.hpp>
+#include <Geode/loader/ModEvent.hpp>
+#include <cocos2d.h>
+#include <functional>
+#include <initializer_list>
+#include <string>
+#include <type_traits>
+
+namespace devtools {
+    template <typename T>
+    concept IsCCNode = std::is_base_of_v<cocos2d::CCNode, std::remove_pointer_t<T>>;
+
+    template <typename T>
+    concept SupportedProperty = std::is_arithmetic_v<T> ||
+                                std::is_same_v<T, std::string> ||
+                                std::is_same_v<T, cocos2d::ccColor3B> ||
+                                std::is_same_v<T, cocos2d::ccColor4B> ||
+                                std::is_same_v<T, cocos2d::ccColor4F> ||
+                                std::is_same_v<T, cocos2d::CCPoint> ||
+                                std::is_same_v<T, cocos2d::CCSize> ||
+                                std::is_same_v<T, cocos2d::CCRect>;
+
+    struct RegisterNodeEvent final : geode::Event {
+        RegisterNodeEvent(std::function<void(cocos2d::CCNode*)>&& callback)
+            : callback(std::move(callback)) {}
+        std::function<void(cocos2d::CCNode*)> callback;
+    };
+
+    template <typename T>
+    struct HandlePropertyEvent final : geode::Event {
+        HandlePropertyEvent(const char* n, T* p) : prop(p), name(n) {}
+        T* prop;
+        const char* name = nullptr;
+        bool changed = false;
+    };
+
+    struct DrawLabelEvent final : geode::Event {
+        DrawLabelEvent(const char* t) : text(t) {}
+        const char* text = nullptr;
+    };
+
+    template <typename T>
+    struct EnumerableEvent final : geode::Event {
+        EnumerableEvent(const char* l, T* v, std::initializer_list<std::pair<T, const char*>> i)
+            : label(l), value(v), items(i) {}
+        const char* label = nullptr;
+        T* value;
+        std::initializer_list<std::pair<T, const char*>> items;
+        bool changed = false;
+    };
+
+    struct ButtonEvent final : geode::Event {
+        ButtonEvent(const char* l) : label(l) {}
+        const char* label = nullptr;
+        bool clicked = false;
+    };
+
+    /// @brief Checks if DevTools is currently loaded.
+    /// @return True if DevTools is loaded, false otherwise.
+    inline bool isLoaded() {
+        return geode::Loader::get()->getLoadedMod("geode.devtools") != nullptr;
+    }
+
+    /// @brief Waits for DevTools to be loaded and then calls the provided callback.
+    /// @param callback The function to call once DevTools is loaded.
+    template <typename F>
+    void waitForDevTools(F&& callback) {
+        if (isLoaded()) {
+            callback();
+        } else {
+            auto devtools = geode::Loader::get()->getInstalledMod("geode.devtools");
+            if (!devtools || !devtools->isEnabled()) return;
+
+            new geode::EventListener(
+                [callback = std::forward<F>(callback)](geode::ModStateEvent*) {
+                    callback();
+                },
+                geode::ModStateFilter(devtools, geode::ModEventType::Loaded)
+            );
+        }
+    }
+
+    /// @brief Registers a callback that will be called whenever a node of type T is opened in Attributes tab.
+    /// @param callback The function to call with the node when it is opened.
+    /// @see `devtools::property`, `devtools::label`, `devtools::enumerable`, `devtools::button`
+    template <typename T, std::invocable<std::remove_pointer_t<T>*> F> requires IsCCNode<T>
+    void registerNode(F&& callback) {
+        RegisterNodeEvent([callback = std::forward<F>(callback)](cocos2d::CCNode* node) {
+            if (auto casted = geode::cast::typeinfo_cast<std::remove_pointer_t<T>*>(node)) {
+                callback(casted);
+            }
+        }).post();
+    }
+
+    /// @brief Renders a property editor for the given value in the DevTools UI.
+    /// @param name The name of the property to display.
+    /// @param prop The property value to edit.
+    /// @return True if the property was changed, false otherwise.
+    /// @warning This function should only ever be called from within a registered node callback.
+    template <typename T> requires SupportedProperty<T>
+    bool property(const char* name, T& prop) {
+        HandlePropertyEvent event(name, &prop);
+        event.post();
+        return event.changed;
+    }
+
+    /// @brief Renders a label in the DevTools UI.
+    /// @param text The text to display in the label.
+    /// @warning This function should only ever be called from within a registered node callback.
+    inline void label(const char* text) {
+        DrawLabelEvent(text).post();
+    }
+
+    /// @brief Renders an enumerable property editor using radio buttons for the given value in the DevTools UI.
+    /// @param label The label for the enumerable property.
+    /// @param value The value to edit, which should be an enum or integral type.
+    /// @param items A list of pairs where each pair contains a value and its corresponding label.
+    /// @return True if the value was changed, false otherwise.
+    /// @warning This function should only ever be called from within a registered node callback.
+    template <typename T> requires std::is_integral_v<std::underlying_type_t<T>>
+    bool enumerable(const char* label, T& value, std::initializer_list<std::pair<T, const char*>> items) {
+        using ValueType = std::underlying_type_t<T>;
+        EnumerableEvent<ValueType> event(
+            label, reinterpret_cast<ValueType*>(&value),
+            *reinterpret_cast<std::initializer_list<std::pair<ValueType, const char*>>*>(&items)
+        );
+        event.post();
+        return event.changed;
+    }
+
+    /// @brief Renders a button in the DevTools UI.
+    /// @param label The label for the button.
+    /// @return True if the button was clicked, false otherwise.
+    /// @warning This function should only ever be called from within a registered node callback.
+    inline bool button(const char* label) {
+        ButtonEvent event(label);
+        event.post();
+        return event.clicked;
+    }
+
+    /// @brief Renders a button in the DevTools UI and calls the provided callback if the button is clicked.
+    /// @param label The label for the button.
+    /// @param callback The function to call when the button is clicked.
+    /// @warning This function should only ever be called from within a registered node callback.
+    template <typename F>
+    void button(const char* label, F&& callback) {
+        if (button(label)) {
+            callback();
+        }
+    }
+}

--- a/mod.json
+++ b/mod.json
@@ -11,6 +11,7 @@
 	"name": "DevTools",
 	"developer": "Geode Team",
 	"description": "Developer tools for Geode",
+	"api": { "include": ["include/*.hpp"] },
 	"links": {
 		"source": "https://github.com/geode-sdk/DevTools"
 	},

--- a/src/API.cpp
+++ b/src/API.cpp
@@ -1,0 +1,139 @@
+#include <API.hpp>
+#include "DevTools.hpp"
+#include "ImGui.hpp"
+#include <misc/cpp/imgui_stdlib.h>
+
+using namespace geode::prelude;
+
+template <typename T>
+static void handleType() {
+    new EventListener<EventFilter<devtools::HandlePropertyEvent<T>>>(+[](devtools::HandlePropertyEvent<T>* event) {
+        constexpr bool isSigned = std::is_signed_v<T>;
+        constexpr ImGuiDataType dataType = sizeof(T) == 1 ? (isSigned ? ImGuiDataType_S8 : ImGuiDataType_U8) :
+                                           sizeof(T) == 2 ? (isSigned ? ImGuiDataType_S16 : ImGuiDataType_U16) :
+                                           sizeof(T) == 4 ? (isSigned ? ImGuiDataType_S32 : ImGuiDataType_U32) :
+                                           isSigned ? ImGuiDataType_S64 : ImGuiDataType_U64;
+        event->changed = ImGui::InputScalar(event->name, dataType, event->prop);
+        return ListenerResult::Stop;
+    });
+
+    new EventListener<EventFilter<devtools::EnumerableEvent<T>>>(+[](devtools::EnumerableEvent<T>* event) {
+        ImGui::Text("%s:", event->label);
+        size_t i = 0;
+        for (auto& [value, label] : event->items) {
+            if (ImGui::RadioButton(label, *event->value == value)) {
+                *event->value = value;
+                event->changed = true;
+            }
+            if (i < event->items.size() - 1) {
+                ImGui::SameLine();
+            }
+            i++;
+        }
+        return ListenerResult::Stop;
+    });
+}
+
+$execute {
+    new EventListener<EventFilter<devtools::RegisterNodeEvent>>(+[](devtools::RegisterNodeEvent* event) {
+        DevTools::get()->addCustomCallback(std::move(event->callback));
+        return ListenerResult::Stop;
+    });
+
+    // Scalars & Enums
+    handleType<char>();
+    handleType<unsigned char>();
+    handleType<short>();
+    handleType<unsigned short>();
+    handleType<int>();
+    handleType<unsigned int>();
+    handleType<long long>();
+    handleType<unsigned long long>();
+    handleType<long>();
+    handleType<unsigned long>();
+
+    // checkbox
+    new EventListener<EventFilter<devtools::HandlePropertyEvent<bool>>>(+[](devtools::HandlePropertyEvent<bool>* event) {
+        event->changed = ImGui::Checkbox(event->name, event->prop);
+        return ListenerResult::Stop;
+    });
+
+    // float and double
+    new EventListener<EventFilter<devtools::HandlePropertyEvent<float>>>(+[](devtools::HandlePropertyEvent<float>* event) {
+        event->changed = ImGui::InputFloat(event->name, event->prop);
+        return ListenerResult::Stop;
+    });
+    new EventListener<EventFilter<devtools::HandlePropertyEvent<double>>>(+[](devtools::HandlePropertyEvent<double>* event) {
+        event->changed = ImGui::InputDouble(event->name, event->prop);
+        return ListenerResult::Stop;
+    });
+
+    // string
+    new EventListener<EventFilter<devtools::HandlePropertyEvent<std::string>>>(+[](devtools::HandlePropertyEvent<std::string>* event) {
+        event->changed = ImGui::InputText(event->name, event->prop);
+        return ListenerResult::Stop;
+    });
+
+    // colors
+    new EventListener<EventFilter<devtools::HandlePropertyEvent<ccColor3B>>>(+[](devtools::HandlePropertyEvent<ccColor3B>* event) {
+        auto color = ImVec4(
+            event->prop->r / 255.f,
+            event->prop->g / 255.f,
+            event->prop->b / 255.f,
+            1.0f
+        );
+        if (ImGui::ColorEdit3(event->name, &color.x)) {
+            event->changed = true;
+            event->prop->r = static_cast<GLubyte>(color.x * 255);
+            event->prop->g = static_cast<GLubyte>(color.y * 255);
+            event->prop->b = static_cast<GLubyte>(color.z * 255);
+        }
+        return ListenerResult::Stop;
+    });
+    new EventListener<EventFilter<devtools::HandlePropertyEvent<ccColor4B>>>(+[](devtools::HandlePropertyEvent<ccColor4B>* event) {
+        auto color = ImVec4(
+            event->prop->r / 255.f,
+            event->prop->g / 255.f,
+            event->prop->b / 255.f,
+            event->prop->a / 255.f
+        );
+        if (ImGui::ColorEdit4(event->name, &color.x)) {
+            event->changed = true;
+            event->prop->r = static_cast<GLubyte>(color.x * 255);
+            event->prop->g = static_cast<GLubyte>(color.y * 255);
+            event->prop->b = static_cast<GLubyte>(color.z * 255);
+            event->prop->a = static_cast<GLubyte>(color.w * 255);
+        }
+        return ListenerResult::Stop;
+    });
+    new EventListener<EventFilter<devtools::HandlePropertyEvent<ccColor4F>>>(+[](devtools::HandlePropertyEvent<ccColor4F>* event) {
+        event->changed = ImGui::ColorEdit4(event->name, reinterpret_cast<float*>(event->prop));
+        return ListenerResult::Stop;
+    });
+
+    // points/sizes
+    new EventListener<EventFilter<devtools::HandlePropertyEvent<CCPoint>>>(+[](devtools::HandlePropertyEvent<CCPoint>* event) {
+        event->changed = ImGui::InputFloat2(event->name, reinterpret_cast<float*>(event->prop));
+        return ListenerResult::Stop;
+    });
+    new EventListener<EventFilter<devtools::HandlePropertyEvent<CCSize>>>(+[](devtools::HandlePropertyEvent<CCSize>* event) {
+        event->changed = ImGui::InputFloat2(event->name, reinterpret_cast<float*>(event->prop));
+        return ListenerResult::Stop;
+    });
+    new EventListener<EventFilter<devtools::HandlePropertyEvent<CCRect>>>(+[](devtools::HandlePropertyEvent<CCRect>* event) {
+        event->changed = ImGui::InputFloat4(event->name, reinterpret_cast<float*>(event->prop));
+        return ListenerResult::Stop;
+    });
+
+    // label
+    new EventListener<EventFilter<devtools::DrawLabelEvent>>(+[](devtools::DrawLabelEvent* event) {
+        ImGui::Text("%s", event->text);
+        return ListenerResult::Stop;
+    });
+
+    // button
+    new EventListener<EventFilter<devtools::ButtonEvent>>(+[](devtools::ButtonEvent* event) {
+        event->clicked = ImGui::Button(event->label);
+        return ListenerResult::Stop;
+    });
+}

--- a/src/DevTools.cpp
+++ b/src/DevTools.cpp
@@ -86,6 +86,10 @@ void DevTools::highlightNode(CCNode* node, HighlightMode mode) {
     m_toHighlight.push_back({ node, mode });
 }
 
+void DevTools::addCustomCallback(std::function<void(CCNode*)> callback) {
+    m_customCallbacks.push_back(std::move(callback));
+}
+
 void DevTools::drawPage(const char* name, void(DevTools::*pageFun)()) {
     if (ImGui::Begin(name, nullptr, ImGuiWindowFlags_HorizontalScrollbar)) {
         (this->*pageFun)();

--- a/src/DevTools.hpp
+++ b/src/DevTools.hpp
@@ -48,6 +48,7 @@ protected:
     CCTexture2D* m_fontTexture = nullptr;
     Ref<CCNode> m_selectedNode;
     std::vector<std::pair<CCNode*, HighlightMode>> m_toHighlight;
+    std::vector<std::function<void(CCNode*)>> m_customCallbacks;
 
     void setupFonts();
     void setupPlatform();
@@ -102,6 +103,8 @@ public:
     CCNode* getSelectedNode() const;
     void selectNode(CCNode* node);
     void highlightNode(CCNode* node, HighlightMode mode);
+
+    void addCustomCallback(std::function<void(CCNode*)> callback);
 
     void sceneChanged();
 

--- a/src/pages/Attributes.cpp
+++ b/src/pages/Attributes.cpp
@@ -39,7 +39,7 @@ void DevTools::drawNodeAttributes(CCNode* node) {
     drawColorAttributes(node);
     drawLabelAttributes(node);
     drawAxisGapAttribute(node);
-    
+
     ImGui::NewLine();
     ImGui::Separator();
     ImGui::NewLine();
@@ -47,8 +47,18 @@ void DevTools::drawNodeAttributes(CCNode* node) {
     drawTextureAttributes(node);
     drawMenuItemAttributes(node);
 
+    for (auto& callback : m_customCallbacks) {
+        ImGui::PushID(&callback);
+        callback(node);
+        ImGui::PopID();
+    }
+
+    ImGui::NewLine();
+    ImGui::Separator();
+    ImGui::NewLine();
+
     drawLayoutOptionsAttributes(node);
-        
+
     ImGui::NewLine();
     ImGui::Separator();
     ImGui::NewLine();


### PR DESCRIPTION
Adds a way for other mods to add custom properties into "Attributes" tab of the inspector.
Here's how it would be used:
```cpp
#include <geode.devtools/include/API.hpp>

class MySprite : public CCSprite {
public:
    enum class RandomEnum {
        Option1,
        Option2,
        Option3
    };

    static void registerDevTools() {
        devtools::registerNode<MySprite>([](MySprite* node) {
            devtools::label("My Sprite");
            devtools::property("Some Flag", node->m_someFlag);
            devtools::property("Some Float", node->m_someFloat);
            devtools::property("Some Int", node->m_someInt);
            devtools::property("Some String", node->m_someString);
            devtools::property("Some Color", node->m_someColor);
            devtools::enumerable("Some Enum", node->m_someEnum, {
                { RandomEnum::Option1, "Option 1" },
                { RandomEnum::Option2, "Option 2" },
                { RandomEnum::Option3, "Option 3" }
            });
            devtools::button("Shake It", [&]{
                node->runAction(CCShaky3D::create(
                    0.5f, CCSize(10, 10), 5, false
                ));
            });
        });
    }

private:
    float m_someFloat = 3.14f;
    int m_someInt = 42;
    std::string m_someString = "text";
    ccColor3B m_someColor = {255, 0, 0};
    RandomEnum m_someEnum = RandomEnum::Option1;
    bool m_someFlag = true;
};

$on_mod(Loaded) {
    // makes sure DevTools is loaded before registering
    devtools::waitForDevTools([] {
        MySprite::registerDevTools();
    });
}
```

in devtools ui it would look like this:
<img width="559" height="603" alt="image" src="https://github.com/user-attachments/assets/31ac5067-6e58-4c6b-873c-fcdd5572abd1" />
