### PR TITLE
add extra-children user object and hide user flag

### DIFF
--- a/src/DevTools.cpp
+++ b/src/DevTools.cpp
@@ -36,6 +36,7 @@ struct matjson::Serialize<Settings> {
         assign(value["button_game"], s.buttonInGame);
         assign(value["button_enabled"], s.buttonEnabled);
         assign(value["tree_drag_reorder"], s.treeDragReorder);
+        assign(value["hide_flagged_nodes"], s.hideFlaggedNodes);
 
         return Ok(s);
     }
@@ -58,7 +59,8 @@ struct matjson::Serialize<Settings> {
             { "button_editor", settings.buttonInEditor },
             { "button_game", settings.buttonInGame },
             { "button_enabled", settings.buttonEnabled },
-            { "tree_drag_reorder", settings.treeDragReorder }
+            { "tree_drag_reorder", settings.treeDragReorder },
+            { "hide_flagged_nodes", settings.hideFlaggedNodes },
         });
     }
 };

--- a/src/DevTools.hpp
+++ b/src/DevTools.hpp
@@ -39,6 +39,19 @@ struct Settings {
     bool hideFlaggedNodes = false;
 };
 
+struct TreeBranchOptions {
+    bool drag = true;
+    bool visible = true;
+    bool fake = false;
+    bool flagHidden = false;
+};
+
+struct ParentNodeInformation {
+    bool drag = true;
+    bool visible = true;
+    bool flagHidden = false;
+};
+
 class DevTools {
 protected:
     bool m_visible = false;
@@ -67,8 +80,8 @@ protected:
     void setupPlatform();
 
     void drawTree();
-    void drawTreeBranch(CCNode* node, size_t index, bool drag, bool visible, bool fake, bool parentHidden);
-    void drawNodeChildren(CCNode* node, bool drag, bool visible, bool parentHidden);
+    void drawTreeBranch(CCNode* node, size_t index, TreeBranchOptions options);
+    void drawNodeChildren(CCNode* node, ParentNodeInformation info);
     void drawSettings();
     void drawAdvancedSettings();
     void drawNodeAttributes(CCNode* node);

--- a/src/DevTools.hpp
+++ b/src/DevTools.hpp
@@ -66,7 +66,7 @@ protected:
     void setupPlatform();
 
     void drawTree();
-    void drawTreeBranch(CCNode* node, size_t index, bool drag, bool visible);
+    void drawTreeBranch(CCNode* node, size_t index, bool drag, bool visible, bool fake);
     void drawSettings();
     void drawAdvancedSettings();
     void drawNodeAttributes(CCNode* node);

--- a/src/DevTools.hpp
+++ b/src/DevTools.hpp
@@ -36,6 +36,7 @@ struct Settings {
     bool buttonInGame = false;
     bool buttonEnabled = false;
     bool treeDragReorder = false;
+    bool hideFlaggedNodes = false;
 };
 
 class DevTools {
@@ -66,7 +67,8 @@ protected:
     void setupPlatform();
 
     void drawTree();
-    void drawTreeBranch(CCNode* node, size_t index, bool drag, bool visible, bool fake);
+    void drawTreeBranch(CCNode* node, size_t index, bool drag, bool visible, bool fake, bool parentHidden);
+    void drawNodeChildren(CCNode* node, bool drag, bool visible, bool parentHidden);
     void drawSettings();
     void drawAdvancedSettings();
     void drawNodeAttributes(CCNode* node);

--- a/src/pages/Settings.cpp
+++ b/src/pages/Settings.cpp
@@ -64,6 +64,14 @@ void DevTools::drawSettings() {
             "(Experimental)\nAllows you to drag/drop nodes in the node tree, changing\ntheir parents or ordering."
         );
     }
+    ImGui::Checkbox("Hide Flagged Nodes", &m_settings.hideFlaggedNodes);
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip(
+            "If enabled, hides nodes in the node tree with the \"geode.devtools/hide\"\n"
+            "user flag set. Allows for hiding nodes irrelevant to debugging, such as containers.\n"
+            "This will keep the children of those nodes visible in the node tree."
+        );
+    }
     ImGui::Checkbox("Advanced Settings", &m_settings.advancedSettings);
     if (ImGui::IsItemHovered()) {
         ImGui::SetTooltip(

--- a/src/pages/Tree.cpp
+++ b/src/pages/Tree.cpp
@@ -13,10 +13,10 @@
 
 using namespace geode::prelude;
 
-std::string formatNodeName(CCNode* node, size_t index, bool fake, bool parentHidden) {
+std::string formatNodeName(CCNode* node, size_t index, bool fake, bool flagHidden) {
     std::string prefix = "";
     if (fake) prefix += "*";
-    if (parentHidden) prefix += "...";
+    if (flagHidden) prefix += "...";
     std::string name = fmt::format("[{}{}] {} ", prefix, index, geode::cocos::getObjectName(node));
     if (node->getTag() != -1) {
         name += fmt::format("({}) ", node->getTag());
@@ -39,17 +39,21 @@ bool isNodeParentOf(CCNode* parent, CCNode* child) {
     return false;
 }
 
-void DevTools::drawTreeBranch(CCNode* node, size_t index, bool drag, bool visible, bool fake, bool parentHidden) {
+void DevTools::drawTreeBranch(CCNode* node, size_t index, TreeBranchOptions options) {
     if (!this->searchBranch(node)) {
         return;
     }
 
     if (node->getUserFlag("hide"_spr) && m_settings.hideFlaggedNodes) {
-        this->drawNodeChildren(node, drag, visible, true);
+        this->drawNodeChildren(node, {
+            .drag = options.drag,
+            .visible = options.visible,
+            .flagHidden = true
+        });
         return;
     }
 
-    visible = node->isVisible() && visible;
+    options.visible = node->isVisible() && options.visible;
 
     auto selected = DevTools::get()->getSelectedNode() == node;
 
@@ -66,7 +70,7 @@ void DevTools::drawTreeBranch(CCNode* node, size_t index, bool drag, bool visibl
 
     bool drawSeparator = false;
 
-    if (auto dragged = this->getDraggedNode(); dragged && dragged != node && !drag && !fake) {
+    if (auto dragged = this->getDraggedNode(); dragged && dragged != node && !options.drag && !options.fake) {
         float mouseY = ImGui::GetMousePos().y;
         float cursorY = ImGui::GetCursorPosY() + ImGui::GetWindowPos().y - ImGui::GetScrollY();
         float height = ImGui::GetTextLineHeight();
@@ -117,10 +121,10 @@ void DevTools::drawTreeBranch(CCNode* node, size_t index, bool drag, bool visibl
     auto alpha = ImGui::GetStyle().DisabledAlpha;
     ImGui::GetStyle().DisabledAlpha = node->isVisible() ? alpha + 0.15f : alpha;
 
-    ImGui::BeginDisabled(!visible);
+    ImGui::BeginDisabled(!options.visible);
     ImGui::PushItemFlag(ImGuiItemFlags_Disabled, false); // Bypass iteract blocking in imgui
 
-    const auto name = formatNodeName(node, index, fake, parentHidden);
+    const auto name = formatNodeName(node, index, options.fake, options.flagHidden);
     // The order here is unusual due to imgui weirdness; see the second-to-last paragraph in https://kahwei.dev/2022/06/20/imgui-tree-node/
     bool expanded = ImGui::TreeNodeEx(node, flags, "%s", name.c_str());
     float height = ImGui::GetItemRectSize().y;
@@ -173,7 +177,11 @@ void DevTools::drawTreeBranch(CCNode* node, size_t index, bool drag, bool visibl
             this->drawNodeAttributes(node);
         }
 
-        this->drawNodeChildren(node, drag || isDrag, visible, false);
+        this->drawNodeChildren(node, {
+            .drag = options.drag || isDrag,
+            .visible = options.visible,
+            .flagHidden = false
+        });
 
         ImGui::TreePop();
     }
@@ -183,16 +191,26 @@ void DevTools::drawTreeBranch(CCNode* node, size_t index, bool drag, bool visibl
     }
 }
 
-void DevTools::drawNodeChildren(CCNode* node, bool drag, bool visible, bool parentHidden) {
+void DevTools::drawNodeChildren(CCNode* node, ParentNodeInformation info) {
     size_t i = 0;
     for (auto& child : CCArrayExt<CCNode*>(node->getChildren())) {
-        this->drawTreeBranch(child, i++, drag, visible, false, parentHidden);
+        this->drawTreeBranch(child, i++, {
+            .drag = info.drag,
+            .visible = info.visible,
+            .fake = false,
+            .flagHidden = info.flagHidden
+        });
     }
 
     i = 0;
     if (auto fakeChildren = typeinfo_cast<CCArray*>(node->getUserObject("extra-children"_spr))) {
         for (auto& child : CCArrayExt<CCNode*>(fakeChildren)) {
-            this->drawTreeBranch(child, i++, drag, visible, true, parentHidden);
+            this->drawTreeBranch(child, i++, {
+                .drag = info.drag,
+                .visible = info.visible,
+                .fake = true,
+                .flagHidden = info.flagHidden
+            });
         }
     }
 }
@@ -212,8 +230,8 @@ void DevTools::drawTree() {
         m_searchQuery.clear();
     }
 
-    this->drawTreeBranch(CCDirector::get()->getRunningScene(), 0, false, true, false, false);
-    this->drawTreeBranch(OverlayManager::get(), 1, false, true, false, false);
+    this->drawTreeBranch(CCDirector::get()->getRunningScene(), 0, { .drag = false });
+    this->drawTreeBranch(OverlayManager::get(), 1, { .drag = false });
 
     if (auto* dragged = this->getDraggedNode()) {
         const auto name = formatNodeName(dragged, 0, false, false);

--- a/src/pages/Tree.cpp
+++ b/src/pages/Tree.cpp
@@ -13,8 +13,8 @@
 
 using namespace geode::prelude;
 
-std::string formatNodeName(CCNode* node, size_t index) {
-    std::string name = fmt::format("[{}] {} ", index, geode::cocos::getObjectName(node));
+std::string formatNodeName(CCNode* node, size_t index, bool fake) {
+    std::string name = fmt::format("[{}{}] {} ", index, fake ? "*" : "", geode::cocos::getObjectName(node));
     if (node->getTag() != -1) {
         name += fmt::format("({}) ", node->getTag());
     }
@@ -36,7 +36,7 @@ bool isNodeParentOf(CCNode* parent, CCNode* child) {
     return false;
 }
 
-void DevTools::drawTreeBranch(CCNode* node, size_t index, bool drag, bool visible) {
+void DevTools::drawTreeBranch(CCNode* node, size_t index, bool drag, bool visible, bool fake) {
     if (!this->searchBranch(node)) {
         return;
     }
@@ -58,7 +58,7 @@ void DevTools::drawTreeBranch(CCNode* node, size_t index, bool drag, bool visibl
 
     bool drawSeparator = false;
 
-    if (auto dragged = this->getDraggedNode(); dragged && dragged != node && !drag) {
+    if (auto dragged = this->getDraggedNode(); dragged && dragged != node && !drag && !fake) {
         float mouseY = ImGui::GetMousePos().y;
         float cursorY = ImGui::GetCursorPosY() + ImGui::GetWindowPos().y - ImGui::GetScrollY();
         float height = ImGui::GetTextLineHeight();
@@ -112,7 +112,7 @@ void DevTools::drawTreeBranch(CCNode* node, size_t index, bool drag, bool visibl
     ImGui::BeginDisabled(!visible);
     ImGui::PushItemFlag(ImGuiItemFlags_Disabled, false); // Bypass iteract blocking in imgui
 
-    const auto name = formatNodeName(node, index);
+    const auto name = formatNodeName(node, index, fake);
     // The order here is unusual due to imgui weirdness; see the second-to-last paragraph in https://kahwei.dev/2022/06/20/imgui-tree-node/
     bool expanded = ImGui::TreeNodeEx(node, flags, "%s", name.c_str());
     float height = ImGui::GetItemRectSize().y;
@@ -164,10 +164,19 @@ void DevTools::drawTreeBranch(CCNode* node, size_t index, bool drag, bool visibl
         if (m_settings.attributesInTree) {
             this->drawNodeAttributes(node);
         }
+
         size_t i = 0;
         for (auto& child : CCArrayExt<CCNode*>(node->getChildren())) {
-            this->drawTreeBranch(child, i++, drag || isDrag, visible);
+            this->drawTreeBranch(child, i++, drag || isDrag, visible, false);
         }
+
+        i = 0;
+        if (auto fakeChildren = typeinfo_cast<CCArray*>(node->getUserObject("extra-children"_spr))) {
+            for (auto& child : CCArrayExt<CCNode*>(fakeChildren)) {
+                this->drawTreeBranch(child, i++, drag || isDrag, visible, true);
+            }
+        }
+
         ImGui::TreePop();
     }
     // on leaf nodes expanded is true
@@ -191,11 +200,11 @@ void DevTools::drawTree() {
         m_searchQuery.clear();
     }
 
-    this->drawTreeBranch(CCDirector::get()->getRunningScene(), 0, false, true);
-    this->drawTreeBranch(OverlayManager::get(), 1, false, true);
+    this->drawTreeBranch(CCDirector::get()->getRunningScene(), 0, false, true, false);
+    this->drawTreeBranch(OverlayManager::get(), 1, false, true, false);
 
     if (auto* dragged = this->getDraggedNode()) {
-        const auto name = formatNodeName(dragged, 0);
+        const auto name = formatNodeName(dragged, 0, false);
         auto bgColor = ImGui::GetColorU32(ImGui::GetStyle().Colors[ImGuiCol_Header]);
         auto textColor = ImGui::GetColorU32(ImGui::GetStyle().Colors[ImGuiCol_Text]);
 

--- a/src/pages/Tree.cpp
+++ b/src/pages/Tree.cpp
@@ -13,8 +13,11 @@
 
 using namespace geode::prelude;
 
-std::string formatNodeName(CCNode* node, size_t index, bool fake) {
-    std::string name = fmt::format("[{}{}] {} ", index, fake ? "*" : "", geode::cocos::getObjectName(node));
+std::string formatNodeName(CCNode* node, size_t index, bool fake, bool parentHidden) {
+    std::string prefix = "";
+    if (fake) prefix += "*";
+    if (parentHidden) prefix += "...";
+    std::string name = fmt::format("[{}{}] {} ", prefix, index, geode::cocos::getObjectName(node));
     if (node->getTag() != -1) {
         name += fmt::format("({}) ", node->getTag());
     }
@@ -36,8 +39,13 @@ bool isNodeParentOf(CCNode* parent, CCNode* child) {
     return false;
 }
 
-void DevTools::drawTreeBranch(CCNode* node, size_t index, bool drag, bool visible, bool fake) {
+void DevTools::drawTreeBranch(CCNode* node, size_t index, bool drag, bool visible, bool fake, bool parentHidden) {
     if (!this->searchBranch(node)) {
+        return;
+    }
+
+    if (node->getUserFlag("hide"_spr) && m_settings.hideFlaggedNodes) {
+        this->drawNodeChildren(node, drag, visible, true);
         return;
     }
 
@@ -112,7 +120,7 @@ void DevTools::drawTreeBranch(CCNode* node, size_t index, bool drag, bool visibl
     ImGui::BeginDisabled(!visible);
     ImGui::PushItemFlag(ImGuiItemFlags_Disabled, false); // Bypass iteract blocking in imgui
 
-    const auto name = formatNodeName(node, index, fake);
+    const auto name = formatNodeName(node, index, fake, parentHidden);
     // The order here is unusual due to imgui weirdness; see the second-to-last paragraph in https://kahwei.dev/2022/06/20/imgui-tree-node/
     bool expanded = ImGui::TreeNodeEx(node, flags, "%s", name.c_str());
     float height = ImGui::GetItemRectSize().y;
@@ -165,23 +173,27 @@ void DevTools::drawTreeBranch(CCNode* node, size_t index, bool drag, bool visibl
             this->drawNodeAttributes(node);
         }
 
-        size_t i = 0;
-        for (auto& child : CCArrayExt<CCNode*>(node->getChildren())) {
-            this->drawTreeBranch(child, i++, drag || isDrag, visible, false);
-        }
-
-        i = 0;
-        if (auto fakeChildren = typeinfo_cast<CCArray*>(node->getUserObject("extra-children"_spr))) {
-            for (auto& child : CCArrayExt<CCNode*>(fakeChildren)) {
-                this->drawTreeBranch(child, i++, drag || isDrag, visible, true);
-            }
-        }
+        this->drawNodeChildren(node, drag || isDrag, visible, false);
 
         ImGui::TreePop();
     }
     // on leaf nodes expanded is true
     if (drawSeparator && (!expanded || !node->getChildrenCount())) {
         ImGui::Separator();
+    }
+}
+
+void DevTools::drawNodeChildren(CCNode* node, bool drag, bool visible, bool parentHidden) {
+    size_t i = 0;
+    for (auto& child : CCArrayExt<CCNode*>(node->getChildren())) {
+        this->drawTreeBranch(child, i++, drag, visible, false, parentHidden);
+    }
+
+    i = 0;
+    if (auto fakeChildren = typeinfo_cast<CCArray*>(node->getUserObject("extra-children"_spr))) {
+        for (auto& child : CCArrayExt<CCNode*>(fakeChildren)) {
+            this->drawTreeBranch(child, i++, drag, visible, true, parentHidden);
+        }
     }
 }
 
@@ -200,11 +212,11 @@ void DevTools::drawTree() {
         m_searchQuery.clear();
     }
 
-    this->drawTreeBranch(CCDirector::get()->getRunningScene(), 0, false, true, false);
-    this->drawTreeBranch(OverlayManager::get(), 1, false, true, false);
+    this->drawTreeBranch(CCDirector::get()->getRunningScene(), 0, false, true, false, false);
+    this->drawTreeBranch(OverlayManager::get(), 1, false, true, false, false);
 
     if (auto* dragged = this->getDraggedNode()) {
-        const auto name = formatNodeName(dragged, 0, false);
+        const auto name = formatNodeName(dragged, 0, false, false);
         auto bgColor = ImGui::GetColorU32(ImGui::GetStyle().Colors[ImGuiCol_Header]);
         auto textColor = ImGui::GetColorU32(ImGui::GetStyle().Colors[ImGuiCol_Text]);
 


### PR DESCRIPTION
extra-children example (these aren't actually in the node tree)
<img width="341" height="122" alt="image" src="https://github.com/user-attachments/assets/0c64e4f4-b185-471c-a2d1-ff08a756785a" />

hide user flag example (m_objectParent and m_objectLayer both have geode.devtools/hide set)
<img width="1431" height="1142" alt="image" src="https://github.com/user-attachments/assets/89b8289a-dca7-4e6c-945f-a8161e57b9dc" />
<img width="252" height="83" alt="image" src="https://github.com/user-attachments/assets/f32503b5-86cf-4d87-b145-49b3bfbd82e2" />

